### PR TITLE
Fix an HTML element name (typo)

### DIFF
--- a/src/SDOM/Elements.purs
+++ b/src/SDOM/Elements.purs
@@ -127,7 +127,7 @@ audio_
   :: forall channel context i o
    . Array (SDOM channel context i o)
   -> SDOM channel context i o
-audio_ = element_ "audich"
+audio_ = element_ "audio"
 
 b
   :: forall channel context i o


### PR DESCRIPTION
I found it wholly by accident, so there could by another typo somewhere. Anyway, this library looks really useful, thanks!